### PR TITLE
Add save-based attacks (save/dc/half) to Attack model and sheetManager

### DIFF
--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -1,6 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 
 from utils import enums
+from utils.constants import STAT_ABBREVIATIONS
 
 if TYPE_CHECKING:
     from cogs5e.models.automation import Automation
@@ -107,6 +108,9 @@ class Attack:
         extra_crit_damage: Optional[str] = None,
         activation_type: Optional[enums.ActivationType] = None,
         list_display_override: Optional[str] = None,
+        save: Optional[str] = None,
+        dc: Optional[str] = None,
+        success_damage: Optional[str] = None,
     ):
         """Creates a new attack for a character."""
         if bonus_calc is not None:
@@ -114,7 +118,9 @@ class Attack:
 
         return cls(
             name,
-            old_to_automation(bonus_calc, damage_calc, details),
+            old_to_automation(
+                bonus_calc, damage_calc, details, save=save, dc=dc, success_damage=success_damage
+            ),
             verb=verb,
             proper=proper,
             criton=criton,
@@ -256,18 +262,29 @@ class AttackList:
         return bool(self.attacks)
 
 
-def old_to_automation(bonus: str | None = None, damage: str | None = None, details: str | None = None):
+def old_to_automation(
+    bonus: str | None = None,
+    damage: str | None = None,
+    details: str | None = None,
+    save: str | None = None,
+    dc: str | None = None,
+    success_damage: str | None = None,
+):
     """Returns an Automation instance representing an old attack."""
     from cogs5e.models import automation
 
-    if damage:
-        damage = automation.Damage(damage)
+    damage_effect = automation.Damage(damage) if damage else None
 
-    if bonus:
-        hit = [damage] if damage else []
+    if save:
+        save = normalize_save_stat(save)
+        fail = [damage_effect] if damage_effect else []
+        success = [automation.Damage(success_damage)] if success_damage else []
+        attack_eff = [automation.Save(save, fail=fail, success=success, dc=dc)]
+    elif bonus:
+        hit = [damage_effect] if damage_effect else []
         attack_eff = [automation.Attack(hit=hit, miss=[], attackBonus=str(bonus).strip("{}<>"))]
     else:
-        attack_eff = [damage] if damage else []
+        attack_eff = [damage_effect] if damage_effect else []
 
     effects = [automation.Target("each", attack_eff)] if attack_eff else []
     if details:
@@ -276,3 +293,11 @@ def old_to_automation(bonus: str | None = None, damage: str | None = None, detai
         effects.append(automation.Text(details))
 
     return automation.Automation(effects)
+
+
+def normalize_save_stat(save: str) -> str:
+    """Normalizes a save stat to its three-letter abbreviation."""
+    save = save.lower()[:3]
+    if save not in STAT_ABBREVIATIONS:
+        raise ValueError(f"{save!r} is not a valid save stat")
+    return save

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -24,8 +24,8 @@ from aliasing import helpers
 from cogs5e.models import embeds
 from cogs5e.models.character import Character
 from cogs5e.models.embeds import EmbedWithAuthor
-from cogs5e.models.errors import ExternalImportError, NoCharacter
-from cogs5e.models.sheet.attack import Attack, AttackList
+from cogs5e.models.errors import ExternalImportError, InvalidArgument, NoCharacter
+from cogs5e.models.sheet.attack import Attack, AttackList, normalize_save_stat
 from cogs5e.sheets.beyond import BeyondSheetParser, DDB_URL_RE, DDB_PDF_URL_RE
 from cogs5e.sheets.dicecloud import DICECLOUD_URL_RE, DicecloudParser
 from cogs5e.sheets.dicecloudv2 import DICECLOUDV2_URL_RE, DicecloudV2Parser
@@ -123,6 +123,9 @@ class SheetManager(commands.Cog):
         __Valid Arguments__
         -d <damage> - How much damage the attack should do.
         -b <to-hit> - The to-hit bonus of the attack.
+        -save <save> - The save ability for this attack (e.g. str, dex, con, int, wis, cha).
+        -dc <dc> - The DC for the save attack.
+        half - When used with -save and -d, successful saves take half damage.
         -desc <description> - A description of the attack.
         -verb <verb> - The verb to use for this attack. (e.g. "Padellis <verb> a dagger!")
         proper - This attack's name is a proper noun.
@@ -151,10 +154,19 @@ class SheetManager(commands.Cog):
         if activation is not None:
             activation = ActivationType(activation)
 
+        damage = parsed.join("d", "+")
+        save = parsed.last("save")
+        if save:
+            try:
+                save = normalize_save_stat(save)
+            except ValueError:
+                raise InvalidArgument(f"{save!r} is not a valid save stat.")
+        success_damage = f"({damage})/2" if save and parsed.last("half", type_=bool) and damage else None
+
         attack = Attack.new(
             name,
             bonus_calc=parsed.join("b", "+"),
-            damage_calc=parsed.join("d", "+"),
+            damage_calc=damage,
             details=parsed.join("desc", "\n"),
             verb=parsed.last("verb"),
             proper=parsed.last("proper", False, bool),
@@ -163,6 +175,9 @@ class SheetManager(commands.Cog):
             thumb=parsed.last("thumb"),
             extra_crit_damage=parsed.last("c"),
             activation_type=activation,
+            save=save,
+            dc=parsed.last("dc"),
+            success_damage=success_damage,
         )
 
         conflict = next((a for a in character.overrides.attacks if a.name.lower() == attack.name.lower()), None)

--- a/tests/e2e/cogs/sheetManager_test.py
+++ b/tests/e2e/cogs/sheetManager_test.py
@@ -2,6 +2,7 @@
 import disnake
 import pytest
 
+from cogs5e.models import automation
 from tests.utils import active_character
 
 pytestmark = pytest.mark.asyncio
@@ -20,6 +21,21 @@ class TestBasicSheetCommands:
 
     async def test_attack_add(self, avrae, dhttp):
         avrae.message("!a add TESTATTACKFOOBAR -b 5 -d 1d6")
+
+    async def test_attack_add_save(self, avrae, dhttp):
+        avrae.message('!a add TESTSAVEFOOBAR -save con -dc 13 -d "2d6[poison]" half')
+        await dhttp.receive_message("Created attack TESTSAVEFOOBAR!")
+
+        character = await active_character(avrae)
+        attack = next(a for a in character.overrides.attacks if a.name == "TESTSAVEFOOBAR")
+        save = attack.automation.effects[0].effects[0]
+
+        assert isinstance(attack.automation.effects[0], automation.Target)
+        assert isinstance(save, automation.Save)
+        assert save.stat == "con"
+        assert save.dc == "13"
+        assert save.fail[0].damage == "2d6[poison]"
+        assert save.success[0].damage == "(2d6[poison])/2"
 
     async def test_attack_delete(self, avrae, dhttp):
         avrae.message("!a delete TESTATTACKFOOBAR")

--- a/tests/unit/attack_model_test.py
+++ b/tests/unit/attack_model_test.py
@@ -1,0 +1,60 @@
+import pytest
+
+from cogs5e.models import automation
+from cogs5e.models.sheet.attack import Attack, normalize_save_stat
+
+
+def test_attack_new_save_for_half_damage():
+    attack = Attack.new(
+        "Poison Breath",
+        damage_calc="2d6[poison]",
+        save="constitution",
+        dc="{spell}",
+        success_damage="(2d6[poison])/2",
+    )
+
+    assert len(attack.automation.effects) == 1
+    target = attack.automation.effects[0]
+    assert isinstance(target, automation.Target)
+    assert target.target == "each"
+
+    save = target.effects[0]
+    assert isinstance(save, automation.Save)
+    assert save.stat == "con"
+    assert save.dc == "{spell}"
+    assert len(save.fail) == 1
+    assert save.fail[0].damage == "2d6[poison]"
+    assert len(save.success) == 1
+    assert save.success[0].damage == "(2d6[poison])/2"
+
+
+def test_attack_new_save_without_half_damage():
+    attack = Attack.new("Poison Breath", damage_calc="2d6[poison]", save="con", dc="{spell}")
+
+    save = attack.automation.effects[0].effects[0]
+    assert save.stat == "con"
+    assert save.fail[0].damage == "2d6[poison]"
+    assert save.success == []
+
+
+def test_attack_new_save_without_damage():
+    attack = Attack.new("Frightful Presence", save="wis", dc="15")
+
+    save = attack.automation.effects[0].effects[0]
+    assert save.stat == "wis"
+    assert save.dc == "15"
+    assert save.fail == []
+    assert save.success == []
+
+
+def test_attack_new_rejects_invalid_save():
+    with pytest.raises(ValueError, match="not a valid save stat"):
+        Attack.new("Bad Save", damage_calc="1d6", save="fortitude", dc="15")
+
+
+@pytest.mark.parametrize(
+    ("raw_save", "expected"),
+    [("str", "str"), ("Strength", "str"), ("DEXTERITY", "dex"), ("charisma", "cha")],
+)
+def test_normalize_save_stat_accepts_abbreviations_and_full_names(raw_save, expected):
+    assert normalize_save_stat(raw_save) == expected


### PR DESCRIPTION
### Motivation
- Add support for attacks that require saving throws (with a DC and optional reduced damage on success) so legacy attack definitions can represent save effects. 
- Normalize and validate save ability input to prevent invalid stats from being persisted.

### Description
- Extended `Attack.new` and `old_to_automation` to accept `save`, `dc`, and `success_damage` and to build an `automation.Save` effect when a save is provided. 
- Added `normalize_save_stat` which normalizes save names to three-letter abbreviations using `STAT_ABBREVIATIONS` and raises `ValueError` for invalid stats. 
- Updated `sheetManager` attack add command to parse `-save` and `-dc`, validate the save via `normalize_save_stat`, support the `half` flag to set `success_damage`, and surface invalid saves as `InvalidArgument`. 
- Adjusted internal handling of damage into `damage_effect` and updated attack automation construction to use `automation.Damage`, `automation.Save`, and `automation.Attack` appropriately. 
- Added unit tests (`tests/unit/attack_model_test.py`) covering save behavior and normalization, and extended the e2e test (`tests/e2e/cogs/sheetManager_test.py`) to exercise adding a save attack.

### Testing
- Ran unit tests for the new model tests with `pytest tests/unit/attack_model_test.py`, and they passed. 
- Exercised the updated e2e scenario `test_attack_add_save` in `tests/e2e/cogs/sheetManager_test.py` which passed in the test environment. 
- Existing attack-related tests were exercised to ensure no regressions were introduced and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d42b4f60832595bbc1ac6fa67f54)